### PR TITLE
Get artifactory info from local.properties

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.8.0-4564"
+arcgisMapsKotlinVersion = "200.7.0"
 
 ### Android versions
 androidGradlePlugin = "8.7.3"
@@ -35,8 +35,8 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 
 ### Application Verions
-versionCode = "2008000"
-versionName = "200.8.0"
+versionCode = "2007000"
+versionName = "200.7.0"
 minSdk = "26"
 targetSdk = "35"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,13 +13,47 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+val localProperties = java.util.Properties().apply {
+    val localPropertiesFile = file("local.properties")
+    if (localPropertiesFile.exists()) {
+        load(localPropertiesFile.inputStream())
+    }
+}
+
+// The Artifactory credentials for the ArcGIS Maps SDK for Kotlin repository.
+// First look for the credentials provided via command line (for CI builds), if not found,
+// take the one defined in local.properties.
+// CI builds pass -PartifactoryURL=${ARTIFACTORY_URL} -PartifactoryUser=${ARTIFACTORY_USER} -PartifactoryPassword=${ARTIFACTORY_PASSWORD}
+val artifactoryUrl: String =
+    providers.gradleProperty("artifactoryUrl").orNull
+        ?: localProperties.getProperty("artifactoryUrl")
+        ?: ""
+
+val artifactoryUsername: String =
+    providers.gradleProperty("artifactoryUsername").orNull
+        ?: localProperties.getProperty("artifactoryUsername")
+        ?: ""
+
+val artifactoryPassword: String =
+    providers.gradleProperty("artifactoryPassword").orNull
+        ?: localProperties.getProperty("artifactoryPassword")
+        ?: ""
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
         maven { url = uri("https://esri.jfrog.io/artifactory/arcgis") }
-        maven { url = uri("https://olympus.esri.com/artifactory/arcgisruntime-repo/") }
+        if (artifactoryUrl != "") {
+            maven {
+                url = java.net.URI(artifactoryUrl)
+                credentials {
+                    username = artifactoryUsername
+                    password = artifactoryPassword
+                }
+            }
+        }
         maven(url = "https://jitpack.io")
     }
 }


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->
Removing internal Artifactory information from public repo to `local.propreties`
## Links and Data
<!--
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a vTest Job for this PR has been run
  - [ ] link:
-->
- a vTest Job for this PR has been run to test setting the credentials through the command line and the changes have been tested locally using gradle.properties to set the Artifactory credentials 
## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->
- Review the `settings.gradle.kts` file to validate that this is the proper way to gather credentials from a `local.properties` file for this use case

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->
Run the following command to build the sample viewer locally to test out these changes
`./gradlew assembleDebug`


<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
